### PR TITLE
Add per-guild rate limit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 
 # Logging
 *.log
+*.csv
 
 # Dependencies
 src/

--- a/mallard/__main__.py
+++ b/mallard/__main__.py
@@ -12,6 +12,7 @@
 
 import argparse
 import logging
+import os
 import sys
 
 from .client import Client
@@ -57,10 +58,6 @@ if __name__ == '__main__':
     main_logger.setLevel(log_level)
     main_logger.addHandler(log_hndl)
 
-    ratelimit_logger = logging.getLogger('mallard.ratelimit')
-    ratelimit_logger.setLevel(logging.INFO)
-    ratelimit_logger.addHandler(log_hndl)
-
     if args.ddg_logs:
         ddg_logger = logging.getLogger('duckduckgo')
         ddg_logger.setLevel(log_level)
@@ -89,10 +86,12 @@ if __name__ == '__main__':
     # Special logging
     path = config['ratelimit']['log']
     if path is not None:
-        ratelimit_hndl = logging.FileHandler(filename=path, mode='a')
-        ratelimit_hndl.setFormatter(logging.Formatter('%(message)s'))
-        ratelimit_logger.addHandler(ratelimit_hndl)
+        if not os.path.isfile(path):
+            ratelimit_handle = open(path, 'w')
+            ratelimit_handle.write("guild_id,user_id\n")
+        else:
+            ratelimit_handle = open(path, 'a')
 
     # Create and run client
-    client = Client(config)
+    client = Client(config, ratelimit_handle)
     client.run(config['bot']['token'])

--- a/mallard/__main__.py
+++ b/mallard/__main__.py
@@ -37,6 +37,9 @@ if __name__ == '__main__':
     argparser.add_argument('-C', '--color', '--colour',
             dest='color',
             help="Override the embed color used by the bot.")
+    argparser.add_argument('-l', '--ratelimit-log',
+            dest='ratelimit_log',
+            help="Override the ratelimit log file used by the bot.")
     argparser.add_argument('-T', '--token',
             dest='token',
             help="Override the bot token used to log in.")
@@ -53,6 +56,10 @@ if __name__ == '__main__':
     main_logger = logging.getLogger('mallard')
     main_logger.setLevel(log_level)
     main_logger.addHandler(log_hndl)
+
+    ratelimit_logger = logging.getLogger('mallard.ratelimit')
+    ratelimit_logger.setLevel(logging.INFO)
+    ratelimit_logger.addHandler(log_hndl)
 
     if args.ddg_logs:
         ddg_logger = logging.getLogger('duckduckgo')
@@ -75,6 +82,16 @@ if __name__ == '__main__':
 
     if args.token is not None:
         config['bot']['token'] = args.token
+
+    if args.ratelimit_log is not None:
+        config['ratelimit']['log'] = args.ratelimit_log
+
+    # Special logging
+    path = config['ratelimit']['log']
+    if path is not None:
+        ratelimit_hndl = logging.FileHandler(filename=path, mode='a')
+        ratelimit_hndl.setFormatter(logging.Formatter('%(message)s'))
+        ratelimit_logger.addHandler(ratelimit_hndl)
 
     # Create and run client
     client = Client(config)

--- a/mallard/client.py
+++ b/mallard/client.py
@@ -150,7 +150,7 @@ class Client(discord.Client):
             with self.rl.try_run(message.guild.id) as ok:
                 if ok:
                     # Ok to send query
-                    result = await duckduckgo.get_zci(query)
+                    result = await duckduckgo.zci(query)
                 else:
                     # This guild has hit the rate limit
                     await message.add_reaction('\U0001f557')

--- a/mallard/client.py
+++ b/mallard/client.py
@@ -11,6 +11,7 @@
 #
 
 from datetime import datetime
+from random import randint
 from typing import Optional
 import logging
 import re
@@ -153,7 +154,7 @@ class Client(discord.Client):
                     result = await duckduckgo.zci(query)
                 else:
                     # This guild has hit the rate limit
-                    await message.add_reaction('\U0001f557')
+                    await message.add_reaction(self.clock_emoji())
                     return
 
         except ValueError:
@@ -203,3 +204,7 @@ class Client(discord.Client):
         embed.set_footer(text=":)")
         embed.set_image(url=MEGANE_URL)
         await channel.send(embed=embed)
+
+    @staticmethod
+    def clock_emoji():
+        return chr(randint(0x1f550, 0x1f567))

--- a/mallard/config.py
+++ b/mallard/config.py
@@ -18,7 +18,10 @@ def load_config(path):
 
     # Required fields
     if not isinstance(obj['bot']['token'], str):
-        return ValueError("Configuration file doesn't specify bot token")
+        raise ValueError("Configuration file doesn't specify bot token")
+
+    if 'ratelimit' not in obj:
+        raise ValueError("Configuration file doesn't specify ratelimit information")
 
     # Optional fields
     if not isinstance(obj.get('mentions', None), list):

--- a/misc/config.yaml
+++ b/misc/config.yaml
@@ -9,6 +9,11 @@ mentions:
 
 color: dark_teal
 
+ratelimit:
+  queries: 2
+  per_seconds: 10
+  log: ratelimit_violations.log
+
 bot:
   username: MyGreatBot#1000
   token: 'MMMMMMMMMMMMMMMMMMMMMMMM.AAAAAA.BBBBBBBBBBBBBBBBBBBBBBBBBBB'

--- a/misc/config.yaml
+++ b/misc/config.yaml
@@ -12,7 +12,7 @@ color: dark_teal
 ratelimit:
   queries: 2
   per_seconds: 10
-  log: ratelimit_violations.log
+  log: ratelimit_violations.csv
 
 bot:
   username: MyGreatBot#1000

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ ratelimit>=1.4.0
 websockets>=3.0
 yarl>=0.12.0
 git+https://github.com/Rapptz/discord.py@rewrite#egg=discord.py
--e git+https://github.com/strinking/python-duckduckgo@master#egg=duckduckgo-async
+-e git+https://github.com/strinking/python-duckduckgo@ratelimit#egg=duckduckgo-async


### PR DESCRIPTION
This uses the new rate limiting in our python-duckduckgo fork to prevent overuse of the DDG API and the whole bot being rate limited. It also logs violations to a specified file.