### PR TITLE
Only follow exclusive results

### DIFF
--- a/mallard/client.py
+++ b/mallard/client.py
@@ -159,7 +159,7 @@ class Client(discord.Client):
             with self.rl.try_run(guild.id) as ok:
                 if ok:
                     # Ok to send query
-                    result = await duckduckgo.zci(query)
+                    zci_result = await duckduckgo.zci_extra(query)
                 else:
                     # This guild has hit the rate limit
                     user = f"{message.author.name}#{message.author.discriminator}"
@@ -181,7 +181,11 @@ class Client(discord.Client):
             embed.description = f"```py\n{traceback.format_exc()}\n```"
             embed.color = discord.Color.red()
         else:
-            result = await try_follow_redirect(result, default=result)
+            (result, result_type) = zci_result
+            logger.info("%s %s", result, result_type)
+            if result_type == 'exclusive':
+                logger.debug("Trying to follow %s", result)
+                result = await try_follow_redirect(result, default=result)
             query = query.replace("`", "'")
 
             embed.title = f"Query: `{query}`"

--- a/mallard/client.py
+++ b/mallard/client.py
@@ -182,7 +182,6 @@ class Client(discord.Client):
             embed.color = discord.Color.red()
         else:
             (result, result_type) = zci_result
-            logger.info("%s %s", result, result_type)
             if result_type == 'exclusive':
                 logger.debug("Trying to follow %s", result)
                 result = await try_follow_redirect(result, default=result)

--- a/mallard/client.py
+++ b/mallard/client.py
@@ -159,7 +159,7 @@ class Client(discord.Client):
             with self.rl.try_run(guild.id) as ok:
                 if ok:
                     # Ok to send query
-                    zci_result = await duckduckgo.zci_extra(query)
+                    zci_result = await duckduckgo.zci_with_type(query)
                 else:
                     # This guild has hit the rate limit
                     user = f"{message.author.name}#{message.author.discriminator}"

--- a/mallard/url.py
+++ b/mallard/url.py
@@ -35,9 +35,7 @@ async def try_follow_redirect(url: str, default: str = None) -> Optional[str]:
             argument, that is returned instead.
     """
 
-    headers = {"User-Agent": "Mozilla/5.0 (Nintendo Switch; WebApplet) AppleWebKit/601.6 (KHTML, like Gecko) NF/4.0.0.10.7 NintendoBrowser/5.2.1.17381"}
-    
-    async with aiohttp.ClientSession(headers=headers) as session:
+    async with aiohttp.ClientSession() as session:
         try:
             async with session.get(url) as response:
                 return str(response.url)


### PR DESCRIPTION
Uses updated library ( https://github.com/strinking/python-duckduckgo/pull/4 ) to pull not only result but also result type which allows to only try to follow results that are of exclusive type. As per ddg api, it seems only exclusive type results are the bang results, e.g. 

https://api.duckduckgo.com/?q=!imdb+rushmore&format=json&pretty=1&no_redirect=1
```json
{
"Abstract": "",
...
"Type": "E",
...
"Redirect": "https://www.imdb.com/find?s=all&q=rushmore",
...
"RelatedTopics": []
}
```

Results that are just ordinary search results return empty type.

Also removes that nintendo user agent that forced mobile links to be resolved.

Checked with these queries:
```
@ddg apple
@ddg ayaya
@ddg valley forge national park
@ddg amazon acnh special edition switch // This one would lock up.
@ddg !aw desktop environment
@ddg arch desktop environment
```