### PR TITLE
Add option for query author to delete query result (0.4.0 -> 0.5.0)

### DIFF
--- a/mallard/__init__.py
+++ b/mallard/__init__.py
@@ -10,7 +10,7 @@
 # WITHOUT ANY WARRANTY. See the LICENSE file for more details.
 #
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"
 
 from .client import Client
 from .config import load_config

--- a/mallard/client.py
+++ b/mallard/client.py
@@ -155,7 +155,10 @@ class Client(discord.Client):
             return
         if reaction.emoji == "\U0001F5D1":
             for relationship in self.query_authors:
-                if relationship[0] == reaction.message.id and relationship[1] == user.id:
+                if (
+                    relationship[0] == reaction.message.id
+                    and relationship[1] == user.id
+                ):
                     logger.debug("Deleting query result for %d", reaction.message.id)
                     await reaction.message.delete()
                     return

--- a/mallard/client.py
+++ b/mallard/client.py
@@ -83,6 +83,9 @@ class QueryOwners:
         self.relationships = []
         self.capacity = capacity
 
+    def __contains__(self, item):
+        return item in self.relationships
+
     def push(self, item):
         self.relationships.insert(0, item)
         if len(self.relationships) > self.capacity:
@@ -171,7 +174,7 @@ class Client(discord.Client):
             logger.debug("Auto-reaction or not reaction to mallard. Ignoring.")
             return
         if reaction.emoji == UNICODE_WASTEBASKET:
-            if (reaction.message.id, user.id) in self.query_owners.relationships:
+            if (reaction.message.id, user.id) in self.query_owners:
                 logger.debug(
                     "Deleting query result for %d at query owner's request",
                     reaction.message.id,


### PR DESCRIPTION
After each query is processed and responded to, mallard sticks a `:wastebasket:` reaction at the bottom of the result message. If the query author adds that reaction, the result message is deleted. Author-query relationships are stored in a list with a capacity of 50. (As such, if mallard goes down, the information is lost, however this is acceptable as the information is non-imperative.)