### PR TITLE
Catch aiohttp/ssl exception for unsupported SSL/TLS protocols

### DIFF
--- a/mallard/url.py
+++ b/mallard/url.py
@@ -40,5 +40,5 @@ async def try_follow_redirect(url: str, default: str = None) -> Optional[str]:
         try:
             async with session.get(url) as response:
                 return str(response.url)
-        except ValueError:
+        except (ValueError, aiohttp.client_exceptions.ClientConnectorSSLError):
             return default


### PR DESCRIPTION
Fixes the issue with errors on sites that use SSL/TLS versions/cipher suites that Python's ssl doesn't support.

For example, the query `peace tower flag` yields `https://www.tpsgc-pwgsc.gc.ca/citeparlementaire-parliamentaryprecinct/decouvrez-discover/drapeaux-demander-flags-request-eng.html`, but when mallard checks the URL for redirects, the command fails because aiohttp throws an SSL error:

```
aiohttp.client_exceptions.ClientConnectorSSLError: Cannot connect to host www.tpsgc-pwgsc.gc.ca:443 ssl:default [[SSL: UNSUPPORTED_PROTOCOL] unsupported protocol (_ssl.c:1108)]
```

Sure enough, running [sslscan](https://github.com/rbsec/sslscan) on `www.tpsgc-pwgsc.gc.ca:443` shows the domain has a limited range of SSL/TLS support:

```
Testing SSL server www.tpsgc-pwgsc.gc.ca on port 443 using SNI name www.tpsgc-pwgsc.gc.ca

  SSL/TLS Protocols:
SSLv2     disabled
SSLv3     disabled
TLSv1.0   enabled
TLSv1.1   disabled
TLSv1.2   disabled
TLSv1.3   disabled

  TLS Fallback SCSV:
Server does not support TLS Fallback SCSV

...

  Supported Server Cipher(s):
Preferred TLSv1.0  256 bits  ECDHE-RSA-AES256-SHA          Curve P-256 DHE 256
Accepted  TLSv1.0  128 bits  ECDHE-RSA-AES128-SHA          Curve P-256 DHE 256
Accepted  TLSv1.0  256 bits  DHE-RSA-CAMELLIA256-SHA       DHE 2048 bits
Accepted  TLSv1.0  256 bits  CAMELLIA256-SHA              
Accepted  TLSv1.0  128 bits  DHE-RSA-CAMELLIA128-SHA       DHE 2048 bits
Accepted  TLSv1.0  128 bits  CAMELLIA128-SHA              
Accepted  TLSv1.0  256 bits  DHE-RSA-AES256-SHA            DHE 2048 bits
Accepted  TLSv1.0  256 bits  AES256-SHA                   
Accepted  TLSv1.0  128 bits  DHE-RSA-AES128-SHA            DHE 2048 bits
Accepted  TLSv1.0  128 bits  AES128-SHA       
```

This PR makes url.py catch the exception `aiohttp.client_exceptions.ClientConnectorSSLError` along with `ValueError`.